### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/IamAmithsharma/7094e826-7dad-49b3-9136-c060e5e05a92/6b8d9fc8-8293-4331-9018-d5bc464b663e/_apis/work/boardbadge/561feb71-a0d2-444c-b676-d8cd97bc0bf4)](https://dev.azure.com/IamAmithsharma/7094e826-7dad-49b3-9136-c060e5e05a92/_boards/board/t/6b8d9fc8-8293-4331-9018-d5bc464b663e/Microsoft.RequirementCategory)
 Added Unit Tests.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/IamAmithsharma/7094e826-7dad-49b3-9136-c060e5e05a92/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.